### PR TITLE
feat: Implement 'All Brands' screen with reusable components✅☕

### DIFF
--- a/lib/common/widgets/products/sort/sortable_products.dart
+++ b/lib/common/widgets/products/sort/sortable_products.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+import 'package:iconsax/iconsax.dart';
+import 'package:qaf_store/common/widgets/layout/grid_view_layout.dart';
+import 'package:qaf_store/common/widgets/products/product_cards/vertical_product_card.dart';
+import 'package:qaf_store/utils/constants/qaf_sizes.dart';
+
+class SortableProducts extends StatelessWidget {
+  const SortableProducts({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      spacing: QafSizes.spaceBtwSections,
+      children: [
+        DropdownButtonFormField(
+          decoration: InputDecoration(prefixIcon: Icon(Iconsax.sort)),
+          items: [
+            'Name',
+            'Higher Price',
+            'Lower Price',
+            'Sale',
+            'Newest',
+            'Popularity'
+          ]
+              .map((option) =>
+                  DropdownMenuItem(value: option, child: Text(option)))
+              .toList(),
+          onChanged: (value) {},
+        ),
+        GridViewLayout(
+          itemCount: 16,
+          itemBuilder: (_, index) => VerticalProductCard(),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/store/screens/brands/all_brands_screen.dart
+++ b/lib/features/store/screens/brands/all_brands_screen.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:qaf_store/common/widgets/appbar/appbar.dart';
+import 'package:qaf_store/common/widgets/cards/brand_card.dart';
+import 'package:qaf_store/common/widgets/layout/grid_view_layout.dart';
+import 'package:qaf_store/common/widgets/texts/section_heading.dart';
+import 'package:qaf_store/features/store/screens/brands/brand_products.dart';
+import 'package:qaf_store/utils/constants/qaf_sizes.dart';
+import 'package:qaf_store/utils/constants/qaf_strings.dart';
+
+class AllBrandsScreen extends StatelessWidget {
+  const AllBrandsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: QafAppBar(
+        title: Text(QafStrings.brands,
+            style: Theme.of(context).textTheme.headlineSmall),
+        showBackArrow: true,
+      ),
+      body: SingleChildScrollView(
+        child: Padding(
+          padding: EdgeInsetsDirectional.all(QafSizes.defaultSpace),
+          child: Column(
+            spacing: QafSizes.spaceBtwSections,
+            children: [
+              SectionHeading(text: QafStrings.brands, isActionButton: false),
+              GridViewLayout(
+                  mainAxisExtent: 70,
+                  itemCount: 12,
+                  itemBuilder: (_, index) => BrandCard(
+                        showBorder: true,
+                        onTap: () => Get.to(() => BrandProducts()),
+                      )),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/store/screens/brands/brand_products.dart
+++ b/lib/features/store/screens/brands/brand_products.dart
@@ -1,23 +1,29 @@
 import 'package:flutter/material.dart';
 import 'package:qaf_store/common/widgets/appbar/appbar.dart';
+import 'package:qaf_store/common/widgets/cards/brand_card.dart';
 import 'package:qaf_store/common/widgets/products/sort/sortable_products.dart';
 import 'package:qaf_store/utils/constants/qaf_sizes.dart';
 
-class AllProductsScreen extends StatelessWidget {
-  const AllProductsScreen({super.key});
+class BrandProducts extends StatelessWidget {
+  const BrandProducts({super.key});
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: QafAppBar(
-        title: Text('Popular Products',
-            style: Theme.of(context).textTheme.headlineSmall),
+        title: Text('Nike', style: Theme.of(context).textTheme.headlineSmall),
         showBackArrow: true,
       ),
       body: SingleChildScrollView(
         child: Padding(
           padding: EdgeInsetsDirectional.all(QafSizes.defaultSpace),
-          child: SortableProducts(),
+          child: Column(
+            spacing: QafSizes.spaceBtwSections,
+            children: [
+              BrandCard(showBorder: true),
+              SortableProducts(),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/features/store/screens/store/store_screen.dart
+++ b/lib/features/store/screens/store/store_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:get/get.dart';
 import 'package:qaf_store/common/widgets/appbar/appbar.dart';
 import 'package:qaf_store/common/widgets/appbar/tabbar.dart';
 import 'package:qaf_store/common/widgets/cards/brand_card.dart';
@@ -7,6 +8,7 @@ import 'package:qaf_store/common/widgets/custom_shapes/containers/qaf_search_con
 import 'package:qaf_store/common/widgets/layout/grid_view_layout.dart';
 import 'package:qaf_store/common/widgets/products/cart/cart_counter_icon.dart';
 import 'package:qaf_store/common/widgets/texts/section_heading.dart';
+import 'package:qaf_store/features/store/screens/brands/all_brands_screen.dart';
 import 'package:qaf_store/features/store/screens/store/widgets/category_tab.dart';
 import 'package:qaf_store/utils/constants/qaf_colors.dart';
 import 'package:qaf_store/utils/constants/qaf_sizes.dart';
@@ -53,7 +55,9 @@ class StoreScreen extends StatelessWidget {
                         ),
                         SizedBox(height: QafSizes.spaceBtwSections),
                         SectionHeading(
-                            text: QafStrings.featuredBrands, onPressed: () {}),
+                          text: QafStrings.featuredBrands,
+                          onPressed: () => Get.to(() => AllBrandsScreen()),
+                        ),
                         SizedBox(height: QafSizes.spaceBtwItems / 1.5),
                         GridViewLayout(
                             mainAxisExtent: 70,

--- a/lib/utils/constants/qaf_strings.dart
+++ b/lib/utils/constants/qaf_strings.dart
@@ -169,4 +169,7 @@ class QafStrings {
   static const String processing = 'Processing';
   static const String order = 'Order';
   static const String shippingDate = 'Shipping Date';
+
+  /// Brand
+  static const String brands = 'Brands';
 }


### PR DESCRIPTION
- Designed 'All Brands' screen with structured layout.
- Reused 'GridView' & 'Brand Card' for optimal performance.
- Enabled navigation to 'brand-specific product listings'.
- Leveraged existing 'Product List' & 'GridView' for seamless integration.
- Ensured full responsiveness & 'Light/Dark Mode' support.

![Screenshot_20250227-200400](https://github.com/user-attachments/assets/96f46a97-7e9e-44ac-9fef-51c230d9a567)
![Screenshot_20250227-200437](https://github.com/user-attachments/assets/936790b1-2496-4b15-974d-26a2f1aeedad)
![Screenshot_20250227-200356](https://github.com/user-attachments/assets/8baf588e-3671-4ac1-8c55-02f73312a6bd)
![Screenshot_20250227-200441](https://github.com/user-attachments/assets/c8065fd6-0a1e-40b6-a50d-386724f87a7a)
