### PR TITLE
feat: Implement user address management screen

### DIFF
--- a/lib/features/screens/address/add_new_address_screen.dart
+++ b/lib/features/screens/address/add_new_address_screen.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:iconsax/iconsax.dart';
 import 'package:qaf_store/common/widgets/appbar/appbar.dart';
+import 'package:qaf_store/features/screens/address/controller/cubit/addresses_cubit.dart';
+import 'package:qaf_store/features/screens/address/widgets/address_bloc_listener.dart';
 import 'package:qaf_store/utils/constants/qaf_sizes.dart';
 import 'package:qaf_store/utils/constants/qaf_strings.dart';
 
@@ -9,6 +12,7 @@ class AddNewAddressScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final addressCubit = context.read<AddressesCubit>();
     return Scaffold(
       appBar: QafAppBar(
         title: Text(QafStrings.addNewAddress),
@@ -18,15 +22,19 @@ class AddNewAddressScreen extends StatelessWidget {
         child: Padding(
           padding: EdgeInsetsDirectional.all(QafSizes.defaultSpace),
           child: Form(
+            key: addressCubit.addressFormKey,
             child: Column(
               spacing: QafSizes.spaceBtwInputFields,
               children: [
                 TextFormField(
+                  controller: addressCubit.nameController,
                   decoration: InputDecoration(
                       prefixIcon: Icon(Iconsax.user),
                       labelText: QafStrings.name),
                 ),
                 TextFormField(
+                  controller: addressCubit.phoneController,
+                  keyboardType: TextInputType.phone,
                   decoration: InputDecoration(
                       prefixIcon: Icon(Iconsax.mobile),
                       labelText: QafStrings.phone),
@@ -36,6 +44,7 @@ class AddNewAddressScreen extends StatelessWidget {
                   children: [
                     Expanded(
                       child: TextFormField(
+                        controller: addressCubit.streetController,
                         decoration: InputDecoration(
                             prefixIcon: Icon(Iconsax.building_31),
                             labelText: QafStrings.street),
@@ -43,6 +52,7 @@ class AddNewAddressScreen extends StatelessWidget {
                     ),
                     Expanded(
                       child: TextFormField(
+                        controller: addressCubit.postalCodeController,
                         decoration: InputDecoration(
                             prefixIcon: Icon(Iconsax.code),
                             labelText: QafStrings.postalCode),
@@ -55,6 +65,7 @@ class AddNewAddressScreen extends StatelessWidget {
                   children: [
                     Expanded(
                       child: TextFormField(
+                        controller: addressCubit.cityController,
                         decoration: InputDecoration(
                             prefixIcon: Icon(Iconsax.buliding),
                             labelText: QafStrings.city),
@@ -62,6 +73,7 @@ class AddNewAddressScreen extends StatelessWidget {
                     ),
                     Expanded(
                       child: TextFormField(
+                        controller: addressCubit.stateController,
                         decoration: InputDecoration(
                             prefixIcon: Icon(Iconsax.activity),
                             labelText: QafStrings.state),
@@ -70,6 +82,7 @@ class AddNewAddressScreen extends StatelessWidget {
                   ],
                 ),
                 TextFormField(
+                  controller: addressCubit.countryController,
                   decoration: InputDecoration(
                       prefixIcon: Icon(Iconsax.global),
                       labelText: QafStrings.country),
@@ -78,7 +91,9 @@ class AddNewAddressScreen extends StatelessWidget {
                 SizedBox(
                     width: double.infinity,
                     child: ElevatedButton(
-                        onPressed: () {}, child: Text(QafStrings.submit)))
+                        onPressed: () => addressCubit.addNewAddress(),
+                        child: Text(QafStrings.submit))),
+                AddressBlocListener(),
               ],
             ),
           ),

--- a/lib/features/screens/address/controller/cubit/addresses_cubit.dart
+++ b/lib/features/screens/address/controller/cubit/addresses_cubit.dart
@@ -1,0 +1,98 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:qaf_store/features/screens/address/controller/cubit/addresses_state.dart';
+import 'package:qaf_store/features/screens/address/data/model/address_model.dart';
+import 'package:qaf_store/features/screens/address/data/repository/address_repository.dart';
+
+class AddressesCubit extends Cubit<AddressesState> {
+  final AddressRepository addressRepository;
+  AddressesCubit(this.addressRepository) : super(AddressesState.initial());
+
+  AddressModel selectedAddress = AddressModel.empty();
+  List<AddressModel> addresses = [];
+  AddressModel addressModel = AddressModel.empty();
+  bool refreshData = true;
+
+  final nameController = TextEditingController();
+  final phoneController = TextEditingController();
+  final streetController = TextEditingController();
+  final postalCodeController = TextEditingController();
+  final cityController = TextEditingController();
+  final countryController = TextEditingController();
+  final stateController = TextEditingController();
+  final addressFormKey = GlobalKey<FormState>();
+
+  Future<void> fetchAllUserAddress() async {
+    try {
+      emit(AddressesState.loading());
+      final addresses = await addressRepository.fetchAllUserAddress();
+      addresses.when(
+          success: (addresses) {
+            addresses.firstWhere((element) => element.selectedAddress,
+                orElse: () => AddressModel.empty());
+            this.addresses = addresses;
+            emit(AddressesState.success(addresses));
+          },
+          failure: (error) => emit(AddressesState.error(error)));
+    } catch (error) {
+      emit(AddressesState.error(error.toString()));
+    }
+  }
+
+  Future selectAddress(AddressModel newSelectedAddress) async {
+    try {
+      if (selectedAddress.id.isNotEmpty) {
+        await addressRepository.updateSelectedUserAddress(
+            selectedAddress.id, false);
+      }
+      newSelectedAddress.selectedAddress = true;
+      selectedAddress = newSelectedAddress;
+      final result = await addressRepository.updateSelectedUserAddress(
+          selectedAddress.id, true);
+      result.when(
+        success: (data) => emit(AddressesState.selected(selectedAddress.id)),
+        failure: (error) => emit(AddressesState.error(error)),
+      );
+    } catch (error) {
+      emit(AddressesState.error(error.toString()));
+    }
+  }
+
+  Future addNewAddress() async {
+    try {
+      emit(AddressesState.addNewAddressLoading());
+      if (!addressFormKey.currentState!.validate()) return;
+
+      addressModel = AddressModel(
+        id: '',
+        name: nameController.text.trim(),
+        phoneNumber: phoneController.text.trim(),
+        street: streetController.text.trim(),
+        city: cityController.text.trim(),
+        state: stateController.text.trim(),
+        postalCode: postalCodeController.text.trim(),
+        country: countryController.text.trim(),
+        selectedAddress: true,
+      );
+
+      final id = await addressRepository.addAddress(addressModel);
+      addressModel.id = id;
+
+      await selectAddress(addressModel);
+
+      emit(AddressesState.addNewAddressSuccess(addressModel.id));
+    } catch (error) {
+      emit(AddressesState.addNewAddressError(error.toString()));
+    }
+  }
+
+  void restFormField() {
+    nameController.clear();
+    phoneController.clear();
+    stateController.clear();
+    streetController.clear();
+    postalCodeController.clear();
+    countryController.clear();
+    cityController.clear();
+  }
+}

--- a/lib/features/screens/address/controller/cubit/addresses_state.dart
+++ b/lib/features/screens/address/controller/cubit/addresses_state.dart
@@ -1,0 +1,16 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:qaf_store/features/screens/address/data/model/address_model.dart';
+
+part 'addresses_state.freezed.dart';
+
+@freezed
+class AddressesState with _$AddressesState {
+  const factory AddressesState.initial() = _Initial;
+  const factory AddressesState.loading() = Loading;
+  const factory AddressesState.success(List<AddressModel> address) = Success;
+  const factory AddressesState.selected(String addressId) = Selected;
+  const factory AddressesState.error(String error) = Error;
+  const factory AddressesState.addNewAddressLoading() = AddNewAddressLoading;
+  const factory AddressesState.addNewAddressSuccess(String addressId) = AddNewAddressSuccess;
+  const factory AddressesState.addNewAddressError(String error) = AddNewAddressError;
+}

--- a/lib/features/screens/address/controller/cubit/addresses_state.freezed.dart
+++ b/lib/features/screens/address/controller/cubit/addresses_state.freezed.dart
@@ -1,0 +1,1431 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'addresses_state.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+/// @nodoc
+mixin _$AddressesState {
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() initial,
+    required TResult Function() loading,
+    required TResult Function(List<AddressModel> address) success,
+    required TResult Function(String addressId) selected,
+    required TResult Function(String error) error,
+    required TResult Function() addNewAddressLoading,
+    required TResult Function(String addressId) addNewAddressSuccess,
+    required TResult Function(String error) addNewAddressError,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? initial,
+    TResult? Function()? loading,
+    TResult? Function(List<AddressModel> address)? success,
+    TResult? Function(String addressId)? selected,
+    TResult? Function(String error)? error,
+    TResult? Function()? addNewAddressLoading,
+    TResult? Function(String addressId)? addNewAddressSuccess,
+    TResult? Function(String error)? addNewAddressError,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? initial,
+    TResult Function()? loading,
+    TResult Function(List<AddressModel> address)? success,
+    TResult Function(String addressId)? selected,
+    TResult Function(String error)? error,
+    TResult Function()? addNewAddressLoading,
+    TResult Function(String addressId)? addNewAddressSuccess,
+    TResult Function(String error)? addNewAddressError,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Initial value) initial,
+    required TResult Function(Loading value) loading,
+    required TResult Function(Success value) success,
+    required TResult Function(Selected value) selected,
+    required TResult Function(Error value) error,
+    required TResult Function(AddNewAddressLoading value) addNewAddressLoading,
+    required TResult Function(AddNewAddressSuccess value) addNewAddressSuccess,
+    required TResult Function(AddNewAddressError value) addNewAddressError,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Initial value)? initial,
+    TResult? Function(Loading value)? loading,
+    TResult? Function(Success value)? success,
+    TResult? Function(Selected value)? selected,
+    TResult? Function(Error value)? error,
+    TResult? Function(AddNewAddressLoading value)? addNewAddressLoading,
+    TResult? Function(AddNewAddressSuccess value)? addNewAddressSuccess,
+    TResult? Function(AddNewAddressError value)? addNewAddressError,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Initial value)? initial,
+    TResult Function(Loading value)? loading,
+    TResult Function(Success value)? success,
+    TResult Function(Selected value)? selected,
+    TResult Function(Error value)? error,
+    TResult Function(AddNewAddressLoading value)? addNewAddressLoading,
+    TResult Function(AddNewAddressSuccess value)? addNewAddressSuccess,
+    TResult Function(AddNewAddressError value)? addNewAddressError,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $AddressesStateCopyWith<$Res> {
+  factory $AddressesStateCopyWith(
+          AddressesState value, $Res Function(AddressesState) then) =
+      _$AddressesStateCopyWithImpl<$Res, AddressesState>;
+}
+
+/// @nodoc
+class _$AddressesStateCopyWithImpl<$Res, $Val extends AddressesState>
+    implements $AddressesStateCopyWith<$Res> {
+  _$AddressesStateCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of AddressesState
+  /// with the given fields replaced by the non-null parameter values.
+}
+
+/// @nodoc
+abstract class _$$InitialImplCopyWith<$Res> {
+  factory _$$InitialImplCopyWith(
+          _$InitialImpl value, $Res Function(_$InitialImpl) then) =
+      __$$InitialImplCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$InitialImplCopyWithImpl<$Res>
+    extends _$AddressesStateCopyWithImpl<$Res, _$InitialImpl>
+    implements _$$InitialImplCopyWith<$Res> {
+  __$$InitialImplCopyWithImpl(
+      _$InitialImpl _value, $Res Function(_$InitialImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of AddressesState
+  /// with the given fields replaced by the non-null parameter values.
+}
+
+/// @nodoc
+
+class _$InitialImpl implements _Initial {
+  const _$InitialImpl();
+
+  @override
+  String toString() {
+    return 'AddressesState.initial()';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType && other is _$InitialImpl);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() initial,
+    required TResult Function() loading,
+    required TResult Function(List<AddressModel> address) success,
+    required TResult Function(String addressId) selected,
+    required TResult Function(String error) error,
+    required TResult Function() addNewAddressLoading,
+    required TResult Function(String addressId) addNewAddressSuccess,
+    required TResult Function(String error) addNewAddressError,
+  }) {
+    return initial();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? initial,
+    TResult? Function()? loading,
+    TResult? Function(List<AddressModel> address)? success,
+    TResult? Function(String addressId)? selected,
+    TResult? Function(String error)? error,
+    TResult? Function()? addNewAddressLoading,
+    TResult? Function(String addressId)? addNewAddressSuccess,
+    TResult? Function(String error)? addNewAddressError,
+  }) {
+    return initial?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? initial,
+    TResult Function()? loading,
+    TResult Function(List<AddressModel> address)? success,
+    TResult Function(String addressId)? selected,
+    TResult Function(String error)? error,
+    TResult Function()? addNewAddressLoading,
+    TResult Function(String addressId)? addNewAddressSuccess,
+    TResult Function(String error)? addNewAddressError,
+    required TResult orElse(),
+  }) {
+    if (initial != null) {
+      return initial();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Initial value) initial,
+    required TResult Function(Loading value) loading,
+    required TResult Function(Success value) success,
+    required TResult Function(Selected value) selected,
+    required TResult Function(Error value) error,
+    required TResult Function(AddNewAddressLoading value) addNewAddressLoading,
+    required TResult Function(AddNewAddressSuccess value) addNewAddressSuccess,
+    required TResult Function(AddNewAddressError value) addNewAddressError,
+  }) {
+    return initial(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Initial value)? initial,
+    TResult? Function(Loading value)? loading,
+    TResult? Function(Success value)? success,
+    TResult? Function(Selected value)? selected,
+    TResult? Function(Error value)? error,
+    TResult? Function(AddNewAddressLoading value)? addNewAddressLoading,
+    TResult? Function(AddNewAddressSuccess value)? addNewAddressSuccess,
+    TResult? Function(AddNewAddressError value)? addNewAddressError,
+  }) {
+    return initial?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Initial value)? initial,
+    TResult Function(Loading value)? loading,
+    TResult Function(Success value)? success,
+    TResult Function(Selected value)? selected,
+    TResult Function(Error value)? error,
+    TResult Function(AddNewAddressLoading value)? addNewAddressLoading,
+    TResult Function(AddNewAddressSuccess value)? addNewAddressSuccess,
+    TResult Function(AddNewAddressError value)? addNewAddressError,
+    required TResult orElse(),
+  }) {
+    if (initial != null) {
+      return initial(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _Initial implements AddressesState {
+  const factory _Initial() = _$InitialImpl;
+}
+
+/// @nodoc
+abstract class _$$LoadingImplCopyWith<$Res> {
+  factory _$$LoadingImplCopyWith(
+          _$LoadingImpl value, $Res Function(_$LoadingImpl) then) =
+      __$$LoadingImplCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$LoadingImplCopyWithImpl<$Res>
+    extends _$AddressesStateCopyWithImpl<$Res, _$LoadingImpl>
+    implements _$$LoadingImplCopyWith<$Res> {
+  __$$LoadingImplCopyWithImpl(
+      _$LoadingImpl _value, $Res Function(_$LoadingImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of AddressesState
+  /// with the given fields replaced by the non-null parameter values.
+}
+
+/// @nodoc
+
+class _$LoadingImpl implements Loading {
+  const _$LoadingImpl();
+
+  @override
+  String toString() {
+    return 'AddressesState.loading()';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType && other is _$LoadingImpl);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() initial,
+    required TResult Function() loading,
+    required TResult Function(List<AddressModel> address) success,
+    required TResult Function(String addressId) selected,
+    required TResult Function(String error) error,
+    required TResult Function() addNewAddressLoading,
+    required TResult Function(String addressId) addNewAddressSuccess,
+    required TResult Function(String error) addNewAddressError,
+  }) {
+    return loading();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? initial,
+    TResult? Function()? loading,
+    TResult? Function(List<AddressModel> address)? success,
+    TResult? Function(String addressId)? selected,
+    TResult? Function(String error)? error,
+    TResult? Function()? addNewAddressLoading,
+    TResult? Function(String addressId)? addNewAddressSuccess,
+    TResult? Function(String error)? addNewAddressError,
+  }) {
+    return loading?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? initial,
+    TResult Function()? loading,
+    TResult Function(List<AddressModel> address)? success,
+    TResult Function(String addressId)? selected,
+    TResult Function(String error)? error,
+    TResult Function()? addNewAddressLoading,
+    TResult Function(String addressId)? addNewAddressSuccess,
+    TResult Function(String error)? addNewAddressError,
+    required TResult orElse(),
+  }) {
+    if (loading != null) {
+      return loading();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Initial value) initial,
+    required TResult Function(Loading value) loading,
+    required TResult Function(Success value) success,
+    required TResult Function(Selected value) selected,
+    required TResult Function(Error value) error,
+    required TResult Function(AddNewAddressLoading value) addNewAddressLoading,
+    required TResult Function(AddNewAddressSuccess value) addNewAddressSuccess,
+    required TResult Function(AddNewAddressError value) addNewAddressError,
+  }) {
+    return loading(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Initial value)? initial,
+    TResult? Function(Loading value)? loading,
+    TResult? Function(Success value)? success,
+    TResult? Function(Selected value)? selected,
+    TResult? Function(Error value)? error,
+    TResult? Function(AddNewAddressLoading value)? addNewAddressLoading,
+    TResult? Function(AddNewAddressSuccess value)? addNewAddressSuccess,
+    TResult? Function(AddNewAddressError value)? addNewAddressError,
+  }) {
+    return loading?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Initial value)? initial,
+    TResult Function(Loading value)? loading,
+    TResult Function(Success value)? success,
+    TResult Function(Selected value)? selected,
+    TResult Function(Error value)? error,
+    TResult Function(AddNewAddressLoading value)? addNewAddressLoading,
+    TResult Function(AddNewAddressSuccess value)? addNewAddressSuccess,
+    TResult Function(AddNewAddressError value)? addNewAddressError,
+    required TResult orElse(),
+  }) {
+    if (loading != null) {
+      return loading(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class Loading implements AddressesState {
+  const factory Loading() = _$LoadingImpl;
+}
+
+/// @nodoc
+abstract class _$$SuccessImplCopyWith<$Res> {
+  factory _$$SuccessImplCopyWith(
+          _$SuccessImpl value, $Res Function(_$SuccessImpl) then) =
+      __$$SuccessImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({List<AddressModel> address});
+}
+
+/// @nodoc
+class __$$SuccessImplCopyWithImpl<$Res>
+    extends _$AddressesStateCopyWithImpl<$Res, _$SuccessImpl>
+    implements _$$SuccessImplCopyWith<$Res> {
+  __$$SuccessImplCopyWithImpl(
+      _$SuccessImpl _value, $Res Function(_$SuccessImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of AddressesState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? address = null,
+  }) {
+    return _then(_$SuccessImpl(
+      null == address
+          ? _value._address
+          : address // ignore: cast_nullable_to_non_nullable
+              as List<AddressModel>,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$SuccessImpl implements Success {
+  const _$SuccessImpl(final List<AddressModel> address) : _address = address;
+
+  final List<AddressModel> _address;
+  @override
+  List<AddressModel> get address {
+    if (_address is EqualUnmodifiableListView) return _address;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_address);
+  }
+
+  @override
+  String toString() {
+    return 'AddressesState.success(address: $address)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$SuccessImpl &&
+            const DeepCollectionEquality().equals(other._address, _address));
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, const DeepCollectionEquality().hash(_address));
+
+  /// Create a copy of AddressesState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$SuccessImplCopyWith<_$SuccessImpl> get copyWith =>
+      __$$SuccessImplCopyWithImpl<_$SuccessImpl>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() initial,
+    required TResult Function() loading,
+    required TResult Function(List<AddressModel> address) success,
+    required TResult Function(String addressId) selected,
+    required TResult Function(String error) error,
+    required TResult Function() addNewAddressLoading,
+    required TResult Function(String addressId) addNewAddressSuccess,
+    required TResult Function(String error) addNewAddressError,
+  }) {
+    return success(address);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? initial,
+    TResult? Function()? loading,
+    TResult? Function(List<AddressModel> address)? success,
+    TResult? Function(String addressId)? selected,
+    TResult? Function(String error)? error,
+    TResult? Function()? addNewAddressLoading,
+    TResult? Function(String addressId)? addNewAddressSuccess,
+    TResult? Function(String error)? addNewAddressError,
+  }) {
+    return success?.call(address);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? initial,
+    TResult Function()? loading,
+    TResult Function(List<AddressModel> address)? success,
+    TResult Function(String addressId)? selected,
+    TResult Function(String error)? error,
+    TResult Function()? addNewAddressLoading,
+    TResult Function(String addressId)? addNewAddressSuccess,
+    TResult Function(String error)? addNewAddressError,
+    required TResult orElse(),
+  }) {
+    if (success != null) {
+      return success(address);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Initial value) initial,
+    required TResult Function(Loading value) loading,
+    required TResult Function(Success value) success,
+    required TResult Function(Selected value) selected,
+    required TResult Function(Error value) error,
+    required TResult Function(AddNewAddressLoading value) addNewAddressLoading,
+    required TResult Function(AddNewAddressSuccess value) addNewAddressSuccess,
+    required TResult Function(AddNewAddressError value) addNewAddressError,
+  }) {
+    return success(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Initial value)? initial,
+    TResult? Function(Loading value)? loading,
+    TResult? Function(Success value)? success,
+    TResult? Function(Selected value)? selected,
+    TResult? Function(Error value)? error,
+    TResult? Function(AddNewAddressLoading value)? addNewAddressLoading,
+    TResult? Function(AddNewAddressSuccess value)? addNewAddressSuccess,
+    TResult? Function(AddNewAddressError value)? addNewAddressError,
+  }) {
+    return success?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Initial value)? initial,
+    TResult Function(Loading value)? loading,
+    TResult Function(Success value)? success,
+    TResult Function(Selected value)? selected,
+    TResult Function(Error value)? error,
+    TResult Function(AddNewAddressLoading value)? addNewAddressLoading,
+    TResult Function(AddNewAddressSuccess value)? addNewAddressSuccess,
+    TResult Function(AddNewAddressError value)? addNewAddressError,
+    required TResult orElse(),
+  }) {
+    if (success != null) {
+      return success(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class Success implements AddressesState {
+  const factory Success(final List<AddressModel> address) = _$SuccessImpl;
+
+  List<AddressModel> get address;
+
+  /// Create a copy of AddressesState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$SuccessImplCopyWith<_$SuccessImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$SelectedImplCopyWith<$Res> {
+  factory _$$SelectedImplCopyWith(
+          _$SelectedImpl value, $Res Function(_$SelectedImpl) then) =
+      __$$SelectedImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({String addressId});
+}
+
+/// @nodoc
+class __$$SelectedImplCopyWithImpl<$Res>
+    extends _$AddressesStateCopyWithImpl<$Res, _$SelectedImpl>
+    implements _$$SelectedImplCopyWith<$Res> {
+  __$$SelectedImplCopyWithImpl(
+      _$SelectedImpl _value, $Res Function(_$SelectedImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of AddressesState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? addressId = null,
+  }) {
+    return _then(_$SelectedImpl(
+      null == addressId
+          ? _value.addressId
+          : addressId // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$SelectedImpl implements Selected {
+  const _$SelectedImpl(this.addressId);
+
+  @override
+  final String addressId;
+
+  @override
+  String toString() {
+    return 'AddressesState.selected(addressId: $addressId)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$SelectedImpl &&
+            (identical(other.addressId, addressId) ||
+                other.addressId == addressId));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, addressId);
+
+  /// Create a copy of AddressesState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$SelectedImplCopyWith<_$SelectedImpl> get copyWith =>
+      __$$SelectedImplCopyWithImpl<_$SelectedImpl>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() initial,
+    required TResult Function() loading,
+    required TResult Function(List<AddressModel> address) success,
+    required TResult Function(String addressId) selected,
+    required TResult Function(String error) error,
+    required TResult Function() addNewAddressLoading,
+    required TResult Function(String addressId) addNewAddressSuccess,
+    required TResult Function(String error) addNewAddressError,
+  }) {
+    return selected(addressId);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? initial,
+    TResult? Function()? loading,
+    TResult? Function(List<AddressModel> address)? success,
+    TResult? Function(String addressId)? selected,
+    TResult? Function(String error)? error,
+    TResult? Function()? addNewAddressLoading,
+    TResult? Function(String addressId)? addNewAddressSuccess,
+    TResult? Function(String error)? addNewAddressError,
+  }) {
+    return selected?.call(addressId);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? initial,
+    TResult Function()? loading,
+    TResult Function(List<AddressModel> address)? success,
+    TResult Function(String addressId)? selected,
+    TResult Function(String error)? error,
+    TResult Function()? addNewAddressLoading,
+    TResult Function(String addressId)? addNewAddressSuccess,
+    TResult Function(String error)? addNewAddressError,
+    required TResult orElse(),
+  }) {
+    if (selected != null) {
+      return selected(addressId);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Initial value) initial,
+    required TResult Function(Loading value) loading,
+    required TResult Function(Success value) success,
+    required TResult Function(Selected value) selected,
+    required TResult Function(Error value) error,
+    required TResult Function(AddNewAddressLoading value) addNewAddressLoading,
+    required TResult Function(AddNewAddressSuccess value) addNewAddressSuccess,
+    required TResult Function(AddNewAddressError value) addNewAddressError,
+  }) {
+    return selected(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Initial value)? initial,
+    TResult? Function(Loading value)? loading,
+    TResult? Function(Success value)? success,
+    TResult? Function(Selected value)? selected,
+    TResult? Function(Error value)? error,
+    TResult? Function(AddNewAddressLoading value)? addNewAddressLoading,
+    TResult? Function(AddNewAddressSuccess value)? addNewAddressSuccess,
+    TResult? Function(AddNewAddressError value)? addNewAddressError,
+  }) {
+    return selected?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Initial value)? initial,
+    TResult Function(Loading value)? loading,
+    TResult Function(Success value)? success,
+    TResult Function(Selected value)? selected,
+    TResult Function(Error value)? error,
+    TResult Function(AddNewAddressLoading value)? addNewAddressLoading,
+    TResult Function(AddNewAddressSuccess value)? addNewAddressSuccess,
+    TResult Function(AddNewAddressError value)? addNewAddressError,
+    required TResult orElse(),
+  }) {
+    if (selected != null) {
+      return selected(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class Selected implements AddressesState {
+  const factory Selected(final String addressId) = _$SelectedImpl;
+
+  String get addressId;
+
+  /// Create a copy of AddressesState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$SelectedImplCopyWith<_$SelectedImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$ErrorImplCopyWith<$Res> {
+  factory _$$ErrorImplCopyWith(
+          _$ErrorImpl value, $Res Function(_$ErrorImpl) then) =
+      __$$ErrorImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({String error});
+}
+
+/// @nodoc
+class __$$ErrorImplCopyWithImpl<$Res>
+    extends _$AddressesStateCopyWithImpl<$Res, _$ErrorImpl>
+    implements _$$ErrorImplCopyWith<$Res> {
+  __$$ErrorImplCopyWithImpl(
+      _$ErrorImpl _value, $Res Function(_$ErrorImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of AddressesState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? error = null,
+  }) {
+    return _then(_$ErrorImpl(
+      null == error
+          ? _value.error
+          : error // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$ErrorImpl implements Error {
+  const _$ErrorImpl(this.error);
+
+  @override
+  final String error;
+
+  @override
+  String toString() {
+    return 'AddressesState.error(error: $error)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ErrorImpl &&
+            (identical(other.error, error) || other.error == error));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, error);
+
+  /// Create a copy of AddressesState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ErrorImplCopyWith<_$ErrorImpl> get copyWith =>
+      __$$ErrorImplCopyWithImpl<_$ErrorImpl>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() initial,
+    required TResult Function() loading,
+    required TResult Function(List<AddressModel> address) success,
+    required TResult Function(String addressId) selected,
+    required TResult Function(String error) error,
+    required TResult Function() addNewAddressLoading,
+    required TResult Function(String addressId) addNewAddressSuccess,
+    required TResult Function(String error) addNewAddressError,
+  }) {
+    return error(this.error);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? initial,
+    TResult? Function()? loading,
+    TResult? Function(List<AddressModel> address)? success,
+    TResult? Function(String addressId)? selected,
+    TResult? Function(String error)? error,
+    TResult? Function()? addNewAddressLoading,
+    TResult? Function(String addressId)? addNewAddressSuccess,
+    TResult? Function(String error)? addNewAddressError,
+  }) {
+    return error?.call(this.error);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? initial,
+    TResult Function()? loading,
+    TResult Function(List<AddressModel> address)? success,
+    TResult Function(String addressId)? selected,
+    TResult Function(String error)? error,
+    TResult Function()? addNewAddressLoading,
+    TResult Function(String addressId)? addNewAddressSuccess,
+    TResult Function(String error)? addNewAddressError,
+    required TResult orElse(),
+  }) {
+    if (error != null) {
+      return error(this.error);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Initial value) initial,
+    required TResult Function(Loading value) loading,
+    required TResult Function(Success value) success,
+    required TResult Function(Selected value) selected,
+    required TResult Function(Error value) error,
+    required TResult Function(AddNewAddressLoading value) addNewAddressLoading,
+    required TResult Function(AddNewAddressSuccess value) addNewAddressSuccess,
+    required TResult Function(AddNewAddressError value) addNewAddressError,
+  }) {
+    return error(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Initial value)? initial,
+    TResult? Function(Loading value)? loading,
+    TResult? Function(Success value)? success,
+    TResult? Function(Selected value)? selected,
+    TResult? Function(Error value)? error,
+    TResult? Function(AddNewAddressLoading value)? addNewAddressLoading,
+    TResult? Function(AddNewAddressSuccess value)? addNewAddressSuccess,
+    TResult? Function(AddNewAddressError value)? addNewAddressError,
+  }) {
+    return error?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Initial value)? initial,
+    TResult Function(Loading value)? loading,
+    TResult Function(Success value)? success,
+    TResult Function(Selected value)? selected,
+    TResult Function(Error value)? error,
+    TResult Function(AddNewAddressLoading value)? addNewAddressLoading,
+    TResult Function(AddNewAddressSuccess value)? addNewAddressSuccess,
+    TResult Function(AddNewAddressError value)? addNewAddressError,
+    required TResult orElse(),
+  }) {
+    if (error != null) {
+      return error(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class Error implements AddressesState {
+  const factory Error(final String error) = _$ErrorImpl;
+
+  String get error;
+
+  /// Create a copy of AddressesState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$ErrorImplCopyWith<_$ErrorImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$AddNewAddressLoadingImplCopyWith<$Res> {
+  factory _$$AddNewAddressLoadingImplCopyWith(_$AddNewAddressLoadingImpl value,
+          $Res Function(_$AddNewAddressLoadingImpl) then) =
+      __$$AddNewAddressLoadingImplCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$AddNewAddressLoadingImplCopyWithImpl<$Res>
+    extends _$AddressesStateCopyWithImpl<$Res, _$AddNewAddressLoadingImpl>
+    implements _$$AddNewAddressLoadingImplCopyWith<$Res> {
+  __$$AddNewAddressLoadingImplCopyWithImpl(_$AddNewAddressLoadingImpl _value,
+      $Res Function(_$AddNewAddressLoadingImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of AddressesState
+  /// with the given fields replaced by the non-null parameter values.
+}
+
+/// @nodoc
+
+class _$AddNewAddressLoadingImpl implements AddNewAddressLoading {
+  const _$AddNewAddressLoadingImpl();
+
+  @override
+  String toString() {
+    return 'AddressesState.addNewAddressLoading()';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$AddNewAddressLoadingImpl);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() initial,
+    required TResult Function() loading,
+    required TResult Function(List<AddressModel> address) success,
+    required TResult Function(String addressId) selected,
+    required TResult Function(String error) error,
+    required TResult Function() addNewAddressLoading,
+    required TResult Function(String addressId) addNewAddressSuccess,
+    required TResult Function(String error) addNewAddressError,
+  }) {
+    return addNewAddressLoading();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? initial,
+    TResult? Function()? loading,
+    TResult? Function(List<AddressModel> address)? success,
+    TResult? Function(String addressId)? selected,
+    TResult? Function(String error)? error,
+    TResult? Function()? addNewAddressLoading,
+    TResult? Function(String addressId)? addNewAddressSuccess,
+    TResult? Function(String error)? addNewAddressError,
+  }) {
+    return addNewAddressLoading?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? initial,
+    TResult Function()? loading,
+    TResult Function(List<AddressModel> address)? success,
+    TResult Function(String addressId)? selected,
+    TResult Function(String error)? error,
+    TResult Function()? addNewAddressLoading,
+    TResult Function(String addressId)? addNewAddressSuccess,
+    TResult Function(String error)? addNewAddressError,
+    required TResult orElse(),
+  }) {
+    if (addNewAddressLoading != null) {
+      return addNewAddressLoading();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Initial value) initial,
+    required TResult Function(Loading value) loading,
+    required TResult Function(Success value) success,
+    required TResult Function(Selected value) selected,
+    required TResult Function(Error value) error,
+    required TResult Function(AddNewAddressLoading value) addNewAddressLoading,
+    required TResult Function(AddNewAddressSuccess value) addNewAddressSuccess,
+    required TResult Function(AddNewAddressError value) addNewAddressError,
+  }) {
+    return addNewAddressLoading(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Initial value)? initial,
+    TResult? Function(Loading value)? loading,
+    TResult? Function(Success value)? success,
+    TResult? Function(Selected value)? selected,
+    TResult? Function(Error value)? error,
+    TResult? Function(AddNewAddressLoading value)? addNewAddressLoading,
+    TResult? Function(AddNewAddressSuccess value)? addNewAddressSuccess,
+    TResult? Function(AddNewAddressError value)? addNewAddressError,
+  }) {
+    return addNewAddressLoading?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Initial value)? initial,
+    TResult Function(Loading value)? loading,
+    TResult Function(Success value)? success,
+    TResult Function(Selected value)? selected,
+    TResult Function(Error value)? error,
+    TResult Function(AddNewAddressLoading value)? addNewAddressLoading,
+    TResult Function(AddNewAddressSuccess value)? addNewAddressSuccess,
+    TResult Function(AddNewAddressError value)? addNewAddressError,
+    required TResult orElse(),
+  }) {
+    if (addNewAddressLoading != null) {
+      return addNewAddressLoading(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class AddNewAddressLoading implements AddressesState {
+  const factory AddNewAddressLoading() = _$AddNewAddressLoadingImpl;
+}
+
+/// @nodoc
+abstract class _$$AddNewAddressSuccessImplCopyWith<$Res> {
+  factory _$$AddNewAddressSuccessImplCopyWith(_$AddNewAddressSuccessImpl value,
+          $Res Function(_$AddNewAddressSuccessImpl) then) =
+      __$$AddNewAddressSuccessImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({String addressId});
+}
+
+/// @nodoc
+class __$$AddNewAddressSuccessImplCopyWithImpl<$Res>
+    extends _$AddressesStateCopyWithImpl<$Res, _$AddNewAddressSuccessImpl>
+    implements _$$AddNewAddressSuccessImplCopyWith<$Res> {
+  __$$AddNewAddressSuccessImplCopyWithImpl(_$AddNewAddressSuccessImpl _value,
+      $Res Function(_$AddNewAddressSuccessImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of AddressesState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? addressId = null,
+  }) {
+    return _then(_$AddNewAddressSuccessImpl(
+      null == addressId
+          ? _value.addressId
+          : addressId // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$AddNewAddressSuccessImpl implements AddNewAddressSuccess {
+  const _$AddNewAddressSuccessImpl(this.addressId);
+
+  @override
+  final String addressId;
+
+  @override
+  String toString() {
+    return 'AddressesState.addNewAddressSuccess(addressId: $addressId)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$AddNewAddressSuccessImpl &&
+            (identical(other.addressId, addressId) ||
+                other.addressId == addressId));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, addressId);
+
+  /// Create a copy of AddressesState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$AddNewAddressSuccessImplCopyWith<_$AddNewAddressSuccessImpl>
+      get copyWith =>
+          __$$AddNewAddressSuccessImplCopyWithImpl<_$AddNewAddressSuccessImpl>(
+              this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() initial,
+    required TResult Function() loading,
+    required TResult Function(List<AddressModel> address) success,
+    required TResult Function(String addressId) selected,
+    required TResult Function(String error) error,
+    required TResult Function() addNewAddressLoading,
+    required TResult Function(String addressId) addNewAddressSuccess,
+    required TResult Function(String error) addNewAddressError,
+  }) {
+    return addNewAddressSuccess(addressId);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? initial,
+    TResult? Function()? loading,
+    TResult? Function(List<AddressModel> address)? success,
+    TResult? Function(String addressId)? selected,
+    TResult? Function(String error)? error,
+    TResult? Function()? addNewAddressLoading,
+    TResult? Function(String addressId)? addNewAddressSuccess,
+    TResult? Function(String error)? addNewAddressError,
+  }) {
+    return addNewAddressSuccess?.call(addressId);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? initial,
+    TResult Function()? loading,
+    TResult Function(List<AddressModel> address)? success,
+    TResult Function(String addressId)? selected,
+    TResult Function(String error)? error,
+    TResult Function()? addNewAddressLoading,
+    TResult Function(String addressId)? addNewAddressSuccess,
+    TResult Function(String error)? addNewAddressError,
+    required TResult orElse(),
+  }) {
+    if (addNewAddressSuccess != null) {
+      return addNewAddressSuccess(addressId);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Initial value) initial,
+    required TResult Function(Loading value) loading,
+    required TResult Function(Success value) success,
+    required TResult Function(Selected value) selected,
+    required TResult Function(Error value) error,
+    required TResult Function(AddNewAddressLoading value) addNewAddressLoading,
+    required TResult Function(AddNewAddressSuccess value) addNewAddressSuccess,
+    required TResult Function(AddNewAddressError value) addNewAddressError,
+  }) {
+    return addNewAddressSuccess(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Initial value)? initial,
+    TResult? Function(Loading value)? loading,
+    TResult? Function(Success value)? success,
+    TResult? Function(Selected value)? selected,
+    TResult? Function(Error value)? error,
+    TResult? Function(AddNewAddressLoading value)? addNewAddressLoading,
+    TResult? Function(AddNewAddressSuccess value)? addNewAddressSuccess,
+    TResult? Function(AddNewAddressError value)? addNewAddressError,
+  }) {
+    return addNewAddressSuccess?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Initial value)? initial,
+    TResult Function(Loading value)? loading,
+    TResult Function(Success value)? success,
+    TResult Function(Selected value)? selected,
+    TResult Function(Error value)? error,
+    TResult Function(AddNewAddressLoading value)? addNewAddressLoading,
+    TResult Function(AddNewAddressSuccess value)? addNewAddressSuccess,
+    TResult Function(AddNewAddressError value)? addNewAddressError,
+    required TResult orElse(),
+  }) {
+    if (addNewAddressSuccess != null) {
+      return addNewAddressSuccess(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class AddNewAddressSuccess implements AddressesState {
+  const factory AddNewAddressSuccess(final String addressId) =
+      _$AddNewAddressSuccessImpl;
+
+  String get addressId;
+
+  /// Create a copy of AddressesState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$AddNewAddressSuccessImplCopyWith<_$AddNewAddressSuccessImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$AddNewAddressErrorImplCopyWith<$Res> {
+  factory _$$AddNewAddressErrorImplCopyWith(_$AddNewAddressErrorImpl value,
+          $Res Function(_$AddNewAddressErrorImpl) then) =
+      __$$AddNewAddressErrorImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({String error});
+}
+
+/// @nodoc
+class __$$AddNewAddressErrorImplCopyWithImpl<$Res>
+    extends _$AddressesStateCopyWithImpl<$Res, _$AddNewAddressErrorImpl>
+    implements _$$AddNewAddressErrorImplCopyWith<$Res> {
+  __$$AddNewAddressErrorImplCopyWithImpl(_$AddNewAddressErrorImpl _value,
+      $Res Function(_$AddNewAddressErrorImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of AddressesState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? error = null,
+  }) {
+    return _then(_$AddNewAddressErrorImpl(
+      null == error
+          ? _value.error
+          : error // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$AddNewAddressErrorImpl implements AddNewAddressError {
+  const _$AddNewAddressErrorImpl(this.error);
+
+  @override
+  final String error;
+
+  @override
+  String toString() {
+    return 'AddressesState.addNewAddressError(error: $error)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$AddNewAddressErrorImpl &&
+            (identical(other.error, error) || other.error == error));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, error);
+
+  /// Create a copy of AddressesState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$AddNewAddressErrorImplCopyWith<_$AddNewAddressErrorImpl> get copyWith =>
+      __$$AddNewAddressErrorImplCopyWithImpl<_$AddNewAddressErrorImpl>(
+          this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() initial,
+    required TResult Function() loading,
+    required TResult Function(List<AddressModel> address) success,
+    required TResult Function(String addressId) selected,
+    required TResult Function(String error) error,
+    required TResult Function() addNewAddressLoading,
+    required TResult Function(String addressId) addNewAddressSuccess,
+    required TResult Function(String error) addNewAddressError,
+  }) {
+    return addNewAddressError(this.error);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? initial,
+    TResult? Function()? loading,
+    TResult? Function(List<AddressModel> address)? success,
+    TResult? Function(String addressId)? selected,
+    TResult? Function(String error)? error,
+    TResult? Function()? addNewAddressLoading,
+    TResult? Function(String addressId)? addNewAddressSuccess,
+    TResult? Function(String error)? addNewAddressError,
+  }) {
+    return addNewAddressError?.call(this.error);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? initial,
+    TResult Function()? loading,
+    TResult Function(List<AddressModel> address)? success,
+    TResult Function(String addressId)? selected,
+    TResult Function(String error)? error,
+    TResult Function()? addNewAddressLoading,
+    TResult Function(String addressId)? addNewAddressSuccess,
+    TResult Function(String error)? addNewAddressError,
+    required TResult orElse(),
+  }) {
+    if (addNewAddressError != null) {
+      return addNewAddressError(this.error);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Initial value) initial,
+    required TResult Function(Loading value) loading,
+    required TResult Function(Success value) success,
+    required TResult Function(Selected value) selected,
+    required TResult Function(Error value) error,
+    required TResult Function(AddNewAddressLoading value) addNewAddressLoading,
+    required TResult Function(AddNewAddressSuccess value) addNewAddressSuccess,
+    required TResult Function(AddNewAddressError value) addNewAddressError,
+  }) {
+    return addNewAddressError(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Initial value)? initial,
+    TResult? Function(Loading value)? loading,
+    TResult? Function(Success value)? success,
+    TResult? Function(Selected value)? selected,
+    TResult? Function(Error value)? error,
+    TResult? Function(AddNewAddressLoading value)? addNewAddressLoading,
+    TResult? Function(AddNewAddressSuccess value)? addNewAddressSuccess,
+    TResult? Function(AddNewAddressError value)? addNewAddressError,
+  }) {
+    return addNewAddressError?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Initial value)? initial,
+    TResult Function(Loading value)? loading,
+    TResult Function(Success value)? success,
+    TResult Function(Selected value)? selected,
+    TResult Function(Error value)? error,
+    TResult Function(AddNewAddressLoading value)? addNewAddressLoading,
+    TResult Function(AddNewAddressSuccess value)? addNewAddressSuccess,
+    TResult Function(AddNewAddressError value)? addNewAddressError,
+    required TResult orElse(),
+  }) {
+    if (addNewAddressError != null) {
+      return addNewAddressError(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class AddNewAddressError implements AddressesState {
+  const factory AddNewAddressError(final String error) =
+      _$AddNewAddressErrorImpl;
+
+  String get error;
+
+  /// Create a copy of AddressesState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$AddNewAddressErrorImplCopyWith<_$AddNewAddressErrorImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/features/screens/address/data/model/address_model.dart
+++ b/lib/features/screens/address/data/model/address_model.dart
@@ -1,7 +1,7 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 
 class AddressModel {
-  final String? id;
+  String id;
   final String name;
   final String phoneNumber;
   final String street;
@@ -9,6 +9,8 @@ class AddressModel {
   final String state;
   final String postalCode;
   final String country;
+  final DateTime? dateTime;
+  bool selectedAddress;
 
   AddressModel({
     required this.id,
@@ -19,6 +21,8 @@ class AddressModel {
     required this.state,
     required this.postalCode,
     required this.country,
+    this.dateTime,
+    this.selectedAddress = true,
   });
 
   static AddressModel empty() => AddressModel(
@@ -41,25 +45,44 @@ class AddressModel {
       'State': state,
       'Street': street,
       'PostalCode': postalCode,
+      'DateTime': DateTime.now(),
+      'SelectedAddress': selectedAddress,
     };
   }
 
-  factory AddressModel.fromSnapshot(
-      DocumentSnapshot<Map<String, dynamic>> document) {
-    if (document.data() != null) {
-      final data = document.data()!;
-      return AddressModel(
-        id: data['Id'] ?? '',
-        name: data['Name'] ?? '',
-        phoneNumber: data['PhoneNumber'] ?? '',
-        city: data['City'] ?? '',
-        country: data['Country'] ?? '',
-        state: data['State'] ?? '',
-        street: data['Street'] ?? '',
-        postalCode: data['PostalCode'] ?? '',
-      );
-    } else {
-      return AddressModel.empty();
-    }
+  factory AddressModel.fromJson(Map<String, dynamic> data) {
+    return AddressModel(
+      id: data['Id'] as String,
+      name: data['Name'] as String,
+      phoneNumber: data['PhoneNumber'] as String,
+      city: data['City'] as String,
+      country: data['Country'] as String,
+      state: data['State'] as String,
+      street: data['Street'] as String,
+      postalCode: data['PostalCode'] as String,
+      dateTime: (data['DateTime'] as Timestamp).toDate(),
+      selectedAddress: data['SelectedAddress'] as bool,
+    );
+  }
+
+  factory AddressModel.fromSnapshot(DocumentSnapshot document) {
+    final data = document.data() as Map<String, dynamic>;
+    return AddressModel(
+      id: document.id,
+      name: data['Name'] ?? '',
+      phoneNumber: data['PhoneNumber'] ?? '',
+      city: data['City'] ?? '',
+      country: data['Country'] ?? '',
+      state: data['State'] ?? '',
+      street: data['Street'] ?? '',
+      postalCode: data['PostalCode'] ?? '',
+      dateTime: (data['DateTime'] as Timestamp).toDate(),
+      selectedAddress: data['SelectedAddress'] as bool,
+    );
+  }
+
+  @override
+  String toString() {
+    return '$street, $city, $state $postalCode, $country';
   }
 }

--- a/lib/features/screens/address/data/repository/address_repository.dart
+++ b/lib/features/screens/address/data/repository/address_repository.dart
@@ -1,0 +1,40 @@
+import 'package:qaf_store/features/screens/address/data/model/address_model.dart';
+import 'package:qaf_store/network/services/addresses/address_service.dart';
+import 'package:qaf_store/network/services/server_result.dart';
+
+class AddressRepository {
+  final AddressService addressService;
+
+  const AddressRepository(this.addressService);
+
+  Future<ServerResult<List<AddressModel>>> fetchAllUserAddress() async {
+    try {
+      final addresses = await addressService.fetchUserAddress();
+      return addresses.when(
+          success: (addresses) => ServerResult.success(addresses),
+          failure: (error) => ServerResult.failure(error));
+    } catch (error) {
+      return ServerResult.failure(error.toString());
+    }
+  }
+
+  Future<ServerResult<void>> updateSelectedUserAddress(
+      String addressId, bool selected) async {
+    try {
+      final address =
+          await addressService.updateSelectedUserAddress(addressId, selected);
+      return ServerResult.success(address);
+    } catch (error) {
+      return ServerResult.failure(error.toString());
+    }
+  }
+
+  Future<String> addAddress(AddressModel address) async {
+    try {
+      final newAddress = await addressService.addUserAddress(address);
+      return newAddress;
+    } catch (error) {
+      throw 'the error with fetch user address in AddressServiceImpl $error';
+    }
+  }
+}

--- a/lib/features/screens/address/user_address_screen.dart
+++ b/lib/features/screens/address/user_address_screen.dart
@@ -1,6 +1,11 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:iconsax/iconsax.dart';
 import 'package:qaf_store/common/widgets/appbar/appbar.dart';
+import 'package:qaf_store/common/widgets/loaders/qaf_shimmer.dart';
+import 'package:qaf_store/features/screens/address/controller/cubit/addresses_cubit.dart';
+import 'package:qaf_store/features/screens/address/controller/cubit/addresses_state.dart';
+import 'package:qaf_store/features/screens/address/data/model/address_model.dart';
 import 'package:qaf_store/features/screens/address/widgets/single_address.dart';
 import 'package:qaf_store/utils/constants/qaf_colors.dart';
 import 'package:qaf_store/utils/constants/qaf_sizes.dart';
@@ -13,6 +18,7 @@ class UserAddressScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final addressesCubit = context.read<AddressesCubit>();
     return Scaffold(
       floatingActionButton: FloatingActionButton(
         onPressed: () => context.pushNamed(Routes.addNewAddressScreen),
@@ -27,13 +33,38 @@ class UserAddressScreen extends StatelessWidget {
       body: SingleChildScrollView(
         child: Padding(
           padding: EdgeInsetsDirectional.all(QafSizes.defaultSpace),
-          child: Column(
-            children: [
-              SingleAddress(isSelectedAddress: false),
-              SingleAddress(isSelectedAddress: true),
-              SingleAddress(isSelectedAddress: false),
-              SingleAddress(isSelectedAddress: false),
-            ],
+          child: BlocBuilder<AddressesCubit, AddressesState>(
+            buildWhen: (previous, current) =>
+                current is Loading || current is Success || current is Error,
+            builder: (context, state) {
+              if (addressesCubit.addresses.isNotEmpty &&
+                  addressesCubit.selectedAddress.id.isEmpty) {
+                final selectedAddress = addressesCubit.addresses.firstWhere(
+                  (address) => address.selectedAddress,
+                  orElse: () => AddressModel.empty(),
+                );
+
+                if (selectedAddress.id.isNotEmpty) {
+                  addressesCubit.selectAddress(selectedAddress);
+                }
+              }
+              return state.maybeWhen(
+                loading: () =>
+                    QafShimmerEffect(width: double.infinity, height: 80),
+                success: (address) {
+                  return ListView.builder(
+                      itemCount: address.length,
+                      shrinkWrap: true,
+                      itemBuilder: (_, index) => SingleAddress(
+                          addressModel: address[index],
+                          onTap: () => context
+                              .read<AddressesCubit>()
+                              .selectAddress(address[index])));
+                },
+                error: (error) => Text('no data found $error'),
+                orElse: () => SizedBox.shrink(),
+              );
+            },
           ),
         ),
       ),

--- a/lib/features/screens/address/widgets/address_bloc_listener.dart
+++ b/lib/features/screens/address/widgets/address_bloc_listener.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:qaf_store/common/widgets/popups/full_screen_loader.dart';
+import 'package:qaf_store/common/widgets/popups/loaders.dart';
+import 'package:qaf_store/features/screens/address/controller/cubit/addresses_cubit.dart';
+import 'package:qaf_store/features/screens/address/controller/cubit/addresses_state.dart';
+import 'package:qaf_store/gen/assets.gen.dart';
+import 'package:qaf_store/utils/constants/qaf_strings.dart';
+import 'package:qaf_store/utils/dependency_inejction/getit.dart';
+import 'package:qaf_store/utils/helper/extensions.dart';
+
+class AddressBlocListener extends StatelessWidget {
+  const AddressBlocListener({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocListener<AddressesCubit, AddressesState>(
+      bloc: getIt<AddressesCubit>(),
+      listener: (context, state) {
+        state.whenOrNull(
+          addNewAddressLoading: () {
+            FullScreenLoader.openLoadingDialog('Storing Address....',
+                Assets.images.animations.a141594AnimationOfDocer, context);
+            context.pop();
+          },
+          addNewAddressSuccess: (data) {
+            context.read<AddressesCubit>().restFormField();
+            Loaders.successSnackBar(
+                context: context,
+                title: QafStrings.congratulations,
+                message: 'The Address has been added Correctly!');
+            context.pop();
+          },
+          addNewAddressError: (error) {
+            Loaders.errorSnackBar(
+                context: context,
+                title: QafStrings.ohSnap,
+                message: error.toString());
+          },
+        );
+      },
+      child: const SizedBox.shrink(),
+    );
+  }
+}

--- a/lib/features/screens/address/widgets/single_address.dart
+++ b/lib/features/screens/address/widgets/single_address.dart
@@ -1,59 +1,80 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:iconsax/iconsax.dart';
 import 'package:qaf_store/common/widgets/custom_shapes/containers/rounded_container.dart';
+import 'package:qaf_store/features/screens/address/controller/cubit/addresses_cubit.dart';
+import 'package:qaf_store/features/screens/address/controller/cubit/addresses_state.dart';
+import 'package:qaf_store/features/screens/address/data/model/address_model.dart';
 import 'package:qaf_store/utils/constants/qaf_colors.dart';
 import 'package:qaf_store/utils/constants/qaf_sizes.dart';
 import 'package:qaf_store/utils/helper/qaf_helper_functions.dart';
 
 class SingleAddress extends StatelessWidget {
-  final bool isSelectedAddress;
-  const SingleAddress({super.key, required this.isSelectedAddress});
+  final AddressModel addressModel;
+  final VoidCallback onTap;
+  const SingleAddress(
+      {super.key, required this.addressModel, required this.onTap});
 
   @override
   Widget build(BuildContext context) {
     final dark = QafHelperFunctions.isDark(context);
-    return RoundedContainer(
-      width: double.infinity,
-      showBorder: true,
-      padding: EdgeInsetsDirectional.all(QafSizes.md),
-      backgroundColor: isSelectedAddress
-          ? QafColors.primary.withValues(alpha: .5)
-          : Colors.transparent,
-      borderColor: isSelectedAddress
-          ? Colors.transparent
-          : dark
-              ? QafColors.darkerGrey
-              : QafColors.grey,
-      margin: EdgeInsetsDirectional.only(bottom: QafSizes.spaceBtwItems),
-      child: Stack(
-        children: [
-          PositionedDirectional(
-            top: 0,
-            end: 5,
-            child: Icon(isSelectedAddress ? Iconsax.tick_circle5 : null,
-                color: isSelectedAddress
-                    ? dark
-                        ? QafColors.light
-                        : QafColors.dark
-                    : null),
+
+    return BlocBuilder<AddressesCubit, AddressesState>(
+      builder: (context, state) {
+        final selectedAddressId =
+            context.read<AddressesCubit>().selectedAddress.id;
+        final isSelectedAddress = selectedAddressId == addressModel.id;
+
+        return GestureDetector(
+          onTap: onTap,
+          child: RoundedContainer(
+            width: double.infinity,
+            showBorder: true,
+            padding: EdgeInsetsDirectional.all(QafSizes.md),
+            backgroundColor: isSelectedAddress
+                ? QafColors.primary.withValues(alpha: .5)
+                : Colors.transparent,
+            borderColor: isSelectedAddress
+                ? Colors.transparent
+                : dark
+                    ? QafColors.darkerGrey
+                    : QafColors.grey,
+            margin: EdgeInsetsDirectional.only(bottom: QafSizes.spaceBtwItems),
+            child: Stack(
+              children: [
+                PositionedDirectional(
+                  top: 0,
+                  end: 5,
+                  child: Icon(isSelectedAddress ? Iconsax.tick_circle5 : null,
+                      color: isSelectedAddress
+                          ? dark
+                              ? QafColors.light
+                              : QafColors.dark
+                          : null),
+                ),
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  spacing: QafSizes.sm / 2,
+                  children: [
+                    Text(
+                      addressModel.name,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: Theme.of(context).textTheme.titleLarge,
+                    ),
+                    Text(addressModel.phoneNumber,
+                        maxLines: 1, overflow: TextOverflow.ellipsis),
+                    Text(
+                        '${addressModel.street}, ${addressModel.city}, ${addressModel.city}',
+                        maxLines: 1,
+                        softWrap: true)
+                  ],
+                )
+              ],
+            ),
           ),
-          Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            spacing: QafSizes.sm / 2,
-            children: [
-              Text(
-                'Karim Slama',
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
-                style: Theme.of(context).textTheme.titleLarge,
-              ),
-              Text('+20 1095856941',
-                  maxLines: 1, overflow: TextOverflow.ellipsis),
-              Text('56 St., Cairo, Egypt', maxLines: 1, softWrap: true)
-            ],
-          )
-        ],
-      ),
+        );
+      },
     );
   }
 }

--- a/lib/features/screens/home/controller/cubit/product_state.dart
+++ b/lib/features/screens/home/controller/cubit/product_state.dart
@@ -37,8 +37,4 @@ class ProductState<T> with _$ProductState<T> {
       List<ProductModel> products) = LoadedProductsByBrand;
   const factory ProductState.errorProductsByBrand(String error) =
       ErrorProductsByBrand;
-      // const factory ProductState.favoriteProductChanged(String productId) =
-      // FavoriteProductChanged;
-      // const factory ProductState.favoriteProductRemoved(String productId) =
-      // FavoriteProductRemoved;
 }

--- a/lib/network/services/addresses/address_service.dart
+++ b/lib/network/services/addresses/address_service.dart
@@ -1,0 +1,8 @@
+import 'package:qaf_store/features/screens/address/data/model/address_model.dart';
+import 'package:qaf_store/network/services/server_result.dart';
+
+abstract class AddressService {
+ Future<ServerResult<List<AddressModel>>> fetchUserAddress();
+ Future<ServerResult<void>> updateSelectedUserAddress(String addressId, bool selected);
+ Future<String> addUserAddress(AddressModel address);
+}

--- a/lib/network/services/addresses/address_service_impl.dart
+++ b/lib/network/services/addresses/address_service_impl.dart
@@ -1,0 +1,60 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:qaf_store/features/screens/address/data/model/address_model.dart';
+import 'package:qaf_store/network/services/addresses/address_service.dart';
+import 'package:qaf_store/network/services/server_result.dart';
+
+class AddressServiceImpl implements AddressService {
+  final firestore = FirebaseFirestore.instance;
+
+  final _userId = FirebaseAuth.instance.currentUser!.uid;
+  @override
+  Future<ServerResult<List<AddressModel>>> fetchUserAddress() async {
+    try {
+      if (_userId.isEmpty) return ServerResult.failure('User Id is Empty');
+      final address = await firestore
+          .collection('users')
+          .doc(_userId)
+          .collection('Addresses')
+          .get();
+      final result = address.docs
+          .map(
+              (documentSnapshot) => AddressModel.fromSnapshot(documentSnapshot))
+          .toList();
+
+      return ServerResult.success(result);
+    } catch (error) {
+      return ServerResult.failure(error.toString());
+    }
+  }
+
+  @override
+  Future<ServerResult<void>> updateSelectedUserAddress(
+      String addressId, bool selected) async {
+    try {
+      final result = await firestore
+          .collection('users')
+          .doc(_userId)
+          .collection('Addresses')
+          .doc(addressId)
+          .update({'SelectedAddress': selected});
+      return ServerResult.success(result);
+    } catch (error) {
+      return ServerResult.failure(error.toString());
+    }
+  }
+
+  @override
+  Future<String> addUserAddress(AddressModel address) async {
+    try {
+      final currentAddress = await firestore
+          .collection('users')
+          .doc(_userId)
+          .collection('Addresses')
+          .add(address.toJson());
+          return currentAddress.id;
+    } catch (error) {
+      throw 'the error with fetch user address in AddressServiceImpl $error';
+    }
+  }
+}

--- a/lib/utils/constants/qaf_strings.dart
+++ b/lib/utils/constants/qaf_strings.dart
@@ -65,7 +65,7 @@ class QafStrings {
       'Your Account successfully created';
   static const String yourAccountCreatedSubTitle =
       'Welcome to Your Ultimate Shopping Destination; Your Account is created, Unleash the Joy of Seamless Online Shopping!';
-  static const String congratulations = 'Congratulations!';
+  static const String congratulations = 'Congratulations! 🎉';
   static const String yourAccountHasBeenCreatedVerifyEmailToContinue =
       'Congratulations!';
   static const String youAreLoggedInPerfectlyNowShopWhteverYouWant =

--- a/lib/utils/dependency_inejction/getit.dart
+++ b/lib/utils/dependency_inejction/getit.dart
@@ -1,4 +1,6 @@
 import 'package:get_it/get_it.dart';
+import 'package:qaf_store/features/screens/address/controller/cubit/addresses_cubit.dart';
+import 'package:qaf_store/features/screens/address/data/repository/address_repository.dart';
 import 'package:qaf_store/features/screens/brands/controller/cubit/brand_cubit.dart';
 import 'package:qaf_store/features/screens/brands/data/repository/brands_repository.dart';
 import 'package:qaf_store/features/screens/forgot_password/controller/cubit/reset_password_cubit.dart';
@@ -21,6 +23,8 @@ import 'package:qaf_store/features/screens/verfiy_email/controller/cubit/verify_
 import 'package:qaf_store/features/screens/verfiy_email/data/repository/verify_email_repository.dart';
 import 'package:qaf_store/features/screens/navigation_menu/cubit/navigation_cubit.dart';
 import 'package:qaf_store/features/screens/wishlist/controller/cubit/favorite_cubit.dart';
+import 'package:qaf_store/network/services/addresses/address_service.dart';
+import 'package:qaf_store/network/services/addresses/address_service_impl.dart';
 import 'package:qaf_store/network/services/auth/auth_service.dart';
 import 'package:qaf_store/network/services/auth/auth_service_impl.dart';
 import 'package:qaf_store/network/services/banners/banners_service.dart';
@@ -51,6 +55,7 @@ Future<void> setupGetIt() async {
   getIt.registerLazySingleton<BannersService>(() => BannersServiceImpl());
   getIt.registerLazySingleton<ProductsService>(() => ProductsServiceImpl());
   getIt.registerLazySingleton<BrandsService>(() => BrandsServiceImpl());
+  getIt.registerLazySingleton<AddressService>(() => AddressServiceImpl());
 
   getIt.registerLazySingleton<RegisterRepository>(
       () => RegisterRepository(getIt(), getIt()));
@@ -70,6 +75,8 @@ Future<void> setupGetIt() async {
       () => ProductsRepository(getIt()));
   getIt
       .registerLazySingleton<BrandsRepository>(() => BrandsRepository(getIt()));
+  getIt
+      .registerLazySingleton<AddressRepository>(() => AddressRepository(getIt()));
 
   getIt.registerFactory<OnboardingCubit>(() => OnboardingCubit());
   getIt.registerFactory<SignUpCubit>(() => SignUpCubit(getIt()));
@@ -88,5 +95,7 @@ Future<void> setupGetIt() async {
       () => UploadCubit(getIt(), getIt(), getIt(), getIt()));
   getIt.registerFactory<FavoriteCubit>(
       () => FavoriteCubit(getIt()));
+  getIt.registerFactory<AddressesCubit>(
+      () => AddressesCubit(getIt()));
 
 }

--- a/lib/utils/routings/app_router.dart
+++ b/lib/utils/routings/app_router.dart
@@ -2,6 +2,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:qaf_store/features/screens/address/add_new_address_screen.dart';
+import 'package:qaf_store/features/screens/address/controller/cubit/addresses_cubit.dart';
 import 'package:qaf_store/features/screens/address/user_address_screen.dart';
 import 'package:qaf_store/features/screens/all_products/all_products_screen.dart';
 import 'package:qaf_store/features/screens/brands/all_brands_screen.dart';
@@ -116,7 +117,7 @@ class AppRouter {
         );
 
       case Routes.subCategoryScreen:
-      final category = settings.arguments as CategoryModel;
+        final category = settings.arguments as CategoryModel;
         return MaterialPageRoute(
           builder: (_) => SubCategoryScreen(category: category),
         );
@@ -179,12 +180,18 @@ class AppRouter {
 
       case Routes.userAddressScreen:
         return MaterialPageRoute(
-          builder: (_) => UserAddressScreen(),
+          builder: (_) => BlocProvider(
+            create: (context) => getIt<AddressesCubit>()..fetchAllUserAddress(),
+            child: UserAddressScreen(),
+          ),
         );
 
       case Routes.addNewAddressScreen:
         return MaterialPageRoute(
-          builder: (_) => AddNewAddressScreen(),
+          builder: (_) => BlocProvider.value(
+            value: getIt<AddressesCubit>(),
+            child: AddNewAddressScreen(),
+          ),
         );
 
       case Routes.uploadDataScreen:


### PR DESCRIPTION
- Added user address management screen to display and manage user addresses.
- Integrated Bloc/Cubit for state management to handle address selection, addition, and updates.
- Enabled users to:
  -- View all saved addresses.
  -- Add new addresses with a form.
  -- Select a default address for future use.
- Improved UI/UX with visual feedback for selected addresses and form validation.
- Utilized Firestore to store and retrieve user addresses.